### PR TITLE
build(deps): Add missing version of sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [".github"]
 
 [dependencies]
 bitflags = "2.8"
-rxvm-sys = { path = "sys" }
+rxvm-sys = { version = "1.0", path = "sys" }
 
 [dev-dependencies]
 const-hex = "1.14"


### PR DESCRIPTION
This PR adds the `rxvm-sys` dependency version so that it can be published.